### PR TITLE
Remove mongo-seed build from CI build, will use less credits per build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,7 @@ jobs:
           name: Docker build and push (commit sha)
           command: |
             docker build --tag ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/pintro-server:${CIRCLE_SHA1} server
-            docker build --tag ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/mongo-seed:${CIRCLE_SHA1} docker/mongo-seed
             docker push ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/pintro-server:${CIRCLE_SHA1}
-            docker push ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/mongo-seed:${CIRCLE_SHA1}
   master_only:
     docker:
       - image: google/cloud-sdk
@@ -37,9 +35,7 @@ jobs:
           name: Docker build and push (latest)
           command: |
             docker build --tag ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/pintro-server:latest server
-            docker build --tag ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/mongo-seed:latest docker/mongo-seed
             docker push ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/pintro-server:latest
-            docker push ${GCLOUD_COMPUTE_ZONE}/${GCLOUD_PROJECT_ID}/mongo-seed:latest
 
 workflows:
   version: 2.1

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-echo $GCLOUD_SERVICE_KEY | base64 --decode -i > ${HOME}/gcloud-service-key.json
-gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json
-
-gcloud docker -- push "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT_ID}/pintro-server"
-gcloud docker -- push "${REGISTRY_ADDRESS}/${REGISTRY_PROJECT_ID}/mongo-seed"


### PR DESCRIPTION
**What's included**
- [x] Removes mongo-seed build step from circleci build. This does not need to build every time and it uses extra credits per build.
- [x] Remove some residual GCloud build scripts that were left in unintentionally.  